### PR TITLE
Fix random number generation bug

### DIFF
--- a/FRONTEND/src/hooks/useFunctions.js
+++ b/FRONTEND/src/hooks/useFunctions.js
@@ -10,7 +10,7 @@ const useFunctions = () => {
 
 	// Generate the computer's move
 	const generateComputerMove = (setComputerMove) => {
-		const randomNumber = Math.floor(Math.random() * !bonus ? 3 : 5);
+		const randomNumber = Math.floor(Math.random() * (bonus ? 5 : 3));
 
 		if (!bonus) {
 			if (randomNumber === 0) {


### PR DESCRIPTION
 The expression *** !bonus** is incorrect because **!bonus** returns a boolean (true or false), and multiplying a number by a boolean will not yield the intended result.